### PR TITLE
Fixed an issue with `preparePlayer` reporting `Please provide a valid file path` when the path has `file://` prefix on ios.

### DIFF
--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -85,6 +85,8 @@ class PlayerController extends ChangeNotifier {
   ///
   ///This behavior is set to ensure that player is only re-initialised for new audio file.
   Future<void> preparePlayer(String path, [double? volume]) async {
+    path = Uri.parse(path).path;
+
     await _readAudioFile(path);
     if ((_playerState == PlayerState.readingComplete &&
         _audioFilePath != null)) {


### PR DESCRIPTION
Currently on iOS, using a path with the `file://` prefix causes an exception. In this commit, I used the `Uri` to obtain the path of the recording file uniformly. relate #35 