### PR TITLE
Updated how normalization works for recorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.5] - 7 Aug, 2022 (Unreleased)
+
+- Breaking: Replaced `normalizationFactor` with `scaleFactor` to scale waves.
+
 ## [0.1.4] - 1 Aug, 2022
 
 - Fixed [#71](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/71) - Bump compileSdkVersion/gradle/kotlin to match flutter 3.0 - thanks [@yohom](https://github.com/yohom)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ AudioWaveforms(
  waveStyle: WaveStyle(showDurationLabel: true),
 ),
 ```
-6. Change frequency of wave update and normalise according to need and platform
+6. Change frequency of wave update and scaling the waves
 ```dart
 late final RecorderController recorderController;
   @override
@@ -150,7 +150,7 @@ late final RecorderController recorderController;
     super.initState();
     recorderController = RecorderController()
       ..updateFrequency = const Duration(milliseconds: 100)
-      ..normalizationFactor = Platform.isAndroid ? 60 : 40;
+      ..scaleFactor = 15;
   }
 ```
 7. Using different types of encoders and sample rate

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,6 +62,7 @@ class _HomeState extends State<Home> with WidgetsBindingObserver {
 
   void _initialiseControllers() {
     recorderController = RecorderController()
+    ..scaleFactor = 15
       ..androidEncoder = AndroidEncoder.aac
       ..androidOutputFormat = AndroidOutputFormat.mpeg4
       ..iosEncoder = IosEncoder.kAudioFormatMPEG4AAC

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_waveforms
 description: A Flutter package that allow you to generate waveform while recording audio or from audio file.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/SimformSolutionsPvtLtd/audio_waveforms
 issue_tracker: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues
 


### PR DESCRIPTION
At first we would just add normalizationFactor to decibel. As decibel is a relative value. This was very inefficient way to normalize.
With this, waves will be scaled against maximum current decibel and ultimate value will be between 0.0 to 1.0.
Now to scale it we will be using `scaleFactor`.

So, `normalizationFactor` is renamed to `scaleFactor` in favor to how it's core logic works.

Addressing #43 issue we have with this PR.