### PR TITLE
fix bug: android call preparePlayer 2nd never callback

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -34,12 +34,10 @@ class AudioPlayer(context: Context, channel: MethodChannel, playerKey: String) {
             player?.prepare()
             playerListener = object : Player.Listener {
                 override fun onPlayerStateChanged(isReady: Boolean, state: Int) {
-                    if (!isPlayerPrepared) {
-                        if (state == Player.STATE_READY) {
-                            player?.volume = volume ?: 1F
-                            isPlayerPrepared = true
-                            result.success(true)
-                        }
+                    if (state == Player.STATE_READY) {
+                        player?.volume = volume ?: 1F
+                        isPlayerPrepared = true
+                        result.success(true)
                     }
                     if (state == Player.STATE_ENDED) {
                         val args: MutableMap<String, Any?> = HashMap()


### PR DESCRIPTION
```
      final path = await recorderController.stop(false);
      if (path != null) {
        debugPrint("Recorded file size: ${File(path).lengthSync()}");
        await  playerController.preparePlayer(path);  // nerver callback
      }
```