### PR TITLE
fix bug: android call preparePlayer 2nd never callback

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -32,6 +32,7 @@ class AudioPlayer(context: Context, channel: MethodChannel, playerKey: String) {
             player = ExoPlayer.Builder(appContext).build()
             player?.addMediaItem(mediaItem)
             player?.prepare()
+            isPlayerPrepared = false
             playerListener = object : Player.Listener {
                 override fun onPlayerStateChanged(isReady: Boolean, state: Int) {
                     if (!isPlayerPrepared) {

--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -90,7 +90,6 @@ class PlayerController extends ChangeNotifier {
   /// it completes, it prepares audio player.
   ///
   Future<void> preparePlayer(String path, [double? volume]) async {
-    path = Uri.parse(path).path;
 
     await _readAudioFile(path);
     if ((_playerState == PlayerState.readingComplete &&


### PR DESCRIPTION
```
  Future<void> preparePlayer(String path, [double? volume]) async {
    path = Uri.parse(path).path;

    await _readAudioFile(path);
    if ((_playerState == PlayerState.readingComplete &&
        _audioFilePath != null)) {
      final isPrepared = await AudioWaveformsInterface.instance
          .preparePlayer(path, _playerKey.toString(), volume);  <<<<<<<< block here
      if (isPrepared) {
        _maxDuration = await getDuration();
        setPlayerState(PlayerState.initialized);
      }
      notifyListeners();
    } else {
      throw "Can not prepare player without reading audio file";
    }
  }
```