### PR TITLE
fix(android): build.gradle namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) { namespace 'com.simform.audio_waveforms' }
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Make it conditional, because it could break the build on Gradle < 8.0