### PR TITLE
Add clipRRect parameter to WaveStyle

### DIFF
--- a/lib/src/audio_waveforms.dart
+++ b/lib/src/audio_waveforms.dart
@@ -112,6 +112,7 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
                 shouldCalculateScrolledPosition:
                     widget.shouldCalculateScrolledPosition,
                 scaleFactor: widget.waveStyle.scaleFactor,
+                clipRRect: widget.waveStyle.clipRRect,
               ),
             ),
           ),

--- a/lib/src/base/audio_waveforms_interface.dart
+++ b/lib/src/base/audio_waveforms_interface.dart
@@ -79,8 +79,11 @@ class AudioWaveformsInterface {
 
   ///platform call to get decibel
   Future<double?> getDecibel() async {
-    var db = await _methodChannel.invokeMethod(Constants.getDecibel);
-    return db;
+    try {
+      return await _methodChannel.invokeMethod(Constants.getDecibel);
+    } catch (e) {
+      return 0;
+    }
   }
 
   ///platform call to check microphone permission

--- a/lib/src/base/wave_style.dart
+++ b/lib/src/base/wave_style.dart
@@ -65,6 +65,9 @@ class WaveStyle {
   /// Value > 0 will be padded right and value < 0 will be padded left.
   final double durationTextPadding;
 
+  /// Applies this clipRRect to waveforms.
+  final RRect? clipRRect;
+
   /// Applies this gradient to waveforms.
   ///
   /// **Use as below**
@@ -113,6 +116,7 @@ class WaveStyle {
     this.durationLinesColor = Colors.blueAccent,
     this.gradient,
     this.scaleFactor = 20.0,
+    this.clipRRect,
   }) : assert(waveThickness < spacing,
             "waveThickness can't be greater than spacing");
 }

--- a/lib/src/painters/recorder_wave_painter.dart
+++ b/lib/src/painters/recorder_wave_painter.dart
@@ -105,6 +105,11 @@ class RecorderWavePainter extends CustomPainter {
       pushBack();
       revertClearlabelCall();
     }
+
+    if (clipRRect != null) {
+      canvas.clipRRect(clipRRect!);
+    }
+
     for (var i = 0; i < waveData.length; i++) {
       ///wave gradient
       if (gradient != null) _waveGradient();
@@ -133,10 +138,6 @@ class RecorderWavePainter extends CustomPainter {
 
     ///calculates scrolled position with respect to duration
     if (shouldCalculateScrolledPosition) _setScrolledDuration(size);
-
-    if (clipRRect != null) {
-      canvas.clipRRect(clipRRect!);
-    }
   }
 
   @override

--- a/lib/src/painters/recorder_wave_painter.dart
+++ b/lib/src/painters/recorder_wave_painter.dart
@@ -49,6 +49,7 @@ class RecorderWavePainter extends CustomPainter {
   final Function(int) setCurrentPositionDuration;
   final bool shouldCalculateScrolledPosition;
   final double scaleFactor;
+  final RRect? clipRRect;
 
   RecorderWavePainter({
     required this.waveData,
@@ -82,6 +83,7 @@ class RecorderWavePainter extends CustomPainter {
     required this.setCurrentPositionDuration,
     required this.shouldCalculateScrolledPosition,
     required this.scaleFactor,
+    this.clipRRect,
   })  : _wavePaint = Paint()
           ..color = waveColor
           ..strokeWidth = waveThickness
@@ -131,6 +133,10 @@ class RecorderWavePainter extends CustomPainter {
 
     ///calculates scrolled position with respect to duration
     if (shouldCalculateScrolledPosition) _setScrolledDuration(size);
+
+    if (clipRRect != null) {
+      canvas.clipRRect(clipRRect!);
+    }
   }
 
   @override


### PR DESCRIPTION
With this, you can provide an RRect to clip paint with to WaveStyle.
For example:
```
AudioWaveforms(
                    size: Size(MediaQuery.of(context).size.width, 200.0),
                    recorderController: recorderController,
                    waveStyle: WaveStyle(
                      clipRRect: RRect.fromLTRBR(0, 0, MediaQuery.of(context).size.width,
                          200, const Radius.circular(18)),
                    ),
                  );
```

This way waveforms can be painted inside a rectangle with border radius.