### PR TITLE
Fixed waveform for audios under 1 second not being extractable on Android

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
@@ -24,7 +24,7 @@ class WaveformExtractor(
 ) {
     private var decoder: MediaCodec? = null
     private var extractor: MediaExtractor? = null
-    private var duration = 0L
+    private var durationMillis = 0L
     private var progress = 0F
     private var currentProgress = 0F
 
@@ -48,7 +48,7 @@ class WaveformExtractor(
             val format = mediaExtractor.getTrackFormat(it)
             val mime = format.getString(MediaFormat.KEY_MIME) ?: ""
             if (mime.contains("audio")) {
-                duration = format.getLong(MediaFormat.KEY_DURATION) / 1000000
+                durationMillis = format.getLong(MediaFormat.KEY_DURATION) / 1000
                 mediaExtractor.selectTrack(it)
                 return format
             }
@@ -101,7 +101,7 @@ class WaveformExtractor(
                         } else {
                             16
                         }
-                        totalSamples = sampleRate.toLong() * duration
+                        totalSamples = (sampleRate.toLong() * durationMillis) / 1000
                         perSamplePoints = totalSamples / expectedPoints
                     }
 


### PR DESCRIPTION
Fixed divison by zero due to duration value being rounded to 0 for audios under 1 second length. I changed the variable from duration (in seconds) to durationMillis which fixes an exception that was thrown.

```
Offset argument contained a NaN value.
'dart:ui/painting.dart':
Failed assertion: line 39 pos 10: '<optimized out>'
```