### PR TITLE
Auto start permission on iOS by waiting for response after user confirms or denies

### DIFF
--- a/ios/Classes/AudioRecorder.swift
+++ b/ios/Classes/AudioRecorder.swift
@@ -4,7 +4,6 @@ import Accelerate
 public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
     var audioRecorder: AVAudioRecorder?
     var path: String?
-    var hasPermission: Bool = false
     var useLegacyNormalization: Bool = false
     var audioUrl: URL?
     var recordedDuration: CMTime = CMTime.zero
@@ -111,7 +110,6 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
         case .undetermined:
             AVAudioSession.sharedInstance().requestRecordPermission() { [unowned self] allowed in
                 DispatchQueue.main.async {
-                    self.hasPermission = allowed
                     result(allowed)
                 }
             }

--- a/ios/Classes/AudioRecorder.swift
+++ b/ios/Classes/AudioRecorder.swift
@@ -112,20 +112,16 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
             AVAudioSession.sharedInstance().requestRecordPermission() { [unowned self] allowed in
                 DispatchQueue.main.async {
                     self.hasPermission = allowed
+                    result(allowed)
                 }
             }
-            break
         case .denied:
-            hasPermission = false
-            break
+            result(false)
         case .granted:
-            hasPermission = true
-            break
+            result(true)
         @unknown default:
-            hasPermission = false
-            break
+            result(false)
         }
-        result(hasPermission)
     }
     public func getEncoder(_ enCoder: Int) -> Int {
         switch(enCoder) {


### PR DESCRIPTION
Currently the checkHasPermission function will return before the user has confirmed or deny permissions. These small changes allow the future to return the proper value.

This allows auto start on iOS to work similar to Android.