### PR TITLE
fix: replace unique key with value key in player key

### DIFF
--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
+import 'dart:math';
 
 import 'package:audio_waveforms/audio_waveforms.dart';
 import 'package:audio_waveforms/src/base/constants.dart';
@@ -31,8 +33,11 @@ class PlayerController extends ChangeNotifier {
   /// Provides [max] duration of currently provided audio file.
   int get maxDuration => _maxDuration;
 
+  final ValueKey<String> _playerKey =
+      ValueKey("${Isolate.current.hashCode}${Random().nextInt(10000)}");
+
   /// An unique key string associated with [this] player only
-  final playerKey = shortHash(UniqueKey());
+  String get playerKey => _playerKey.value;
 
   final bool _shouldClearLabels = false;
 


### PR DESCRIPTION
**Issue**: Player key is not unique when running in release mode on iOS.

**Description**: 
- The current implementation uses UniqueKey to generate the player key, which may not guarantee uniqueness in release mode due to Dart's optimizations.
- This can lead to conflicts and unexpected behavior as multiple PlayerController instances may end up with the same key.

**Proposed Solution**:
- Implement a more robust method to generate unique keys for PlayerController instances.
- Use a combination of Isolate.current.hashCode and Random().nextInt(10000) to ensure the uniqueness of the player key.

**Changes Made:** 
- Updated the _playerKey initialization in PlayerController to use Isolate.current.hashCode and Random().nextInt(10000).

**Testing**:
- Verified the solution in both debug and release modes on iOS and Android to ensure effectiveness and uniqueness of the player keys.