### PR TITLE
Only dispose of instance if all playerKeys are removed

### DIFF
--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -279,7 +279,7 @@ class PlayerController extends ChangeNotifier {
     if (playerState != PlayerState.stopped) await stopPlayer();
     await release();
     PlatformStreams.instance.playerControllerFactory.remove(playerKey);
-    if (PlatformStreams.instance.playerControllerFactory.length == 1) {
+    if (PlatformStreams.instance.playerControllerFactory.isEmpty) {
       PlatformStreams.instance.dispose();
     }
     _isDisposed = true;


### PR DESCRIPTION
## Issue
Currently the dispose method will remove the platform instance if there is still one player currently activate.

## Fix
Wait until all players are being disposed to remove the platform instance.