### PR TITLE
Allow seekTo to go to millisecond rather than floored second

### DIFF
--- a/ios/Classes/AudioPlayer.swift
+++ b/ios/Classes/AudioPlayer.swift
@@ -129,7 +129,7 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
 
     func seekTo(_ time: Int?, _ result: @escaping FlutterResult) {
         if(time != nil) {
-            player?.currentTime = Double(time! / 1000)
+            player?.currentTime = TimeInterval(time! / 1000)
             sendCurrentDuration()
             result(true)
         } else {


### PR DESCRIPTION
## Issue
Currently when seeking on iOS the seek time will go to the closest second. This is because the int is first divided by 1000 which floors it and then it is converted to a double.

## Fix
First convert int then divide it by 1000 to convert it into seconds.