### PR TITLE
Fix return type for stopAllPlayers on PlayerController

### DIFF
--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -290,7 +290,7 @@ class PlayerController extends ChangeNotifier {
   ///
   /// This method will close the stream and free resources taken by all
   /// players. This method will not dispose controller.
-  void stopAllPlayers() async {
+  Future<void> stopAllPlayers() async {
     PlatformStreams.instance.dispose();
     await AudioWaveformsInterface.instance.stopAllPlayers();
     PlatformStreams.instance.playerControllerFactory.clear();


### PR DESCRIPTION
## Issue
stopAllPlayers is an async method, but the return type does not have a Future. This means calling this method cannot be awaited.