### PR TITLE
Fix language version incompatibility in  audio_waveforms package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/SimformSolutionsPvtLtd/audio_waveforms
 issue_tracker: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=1.20.0"
 
 dependencies:


### PR DESCRIPTION
The 
audio_waveforms package currently specifies a minimum SDK version of 2.12.0, which is below the minimum required for using **enhanced enums** (2.17 or higher). This pull request updates the **sdk** constraint to 2.17.0, allowing users to utilize enhanced enums within the package without encountering errors.

Closes #340 