### PR TITLE
Fix `setFinishMode` hanging because of not returning result

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -189,6 +189,11 @@ class AudioPlayer(
 
     fun setFinishMode(result: MethodChannel.Result, releaseModeType: Int?) {
         try {
+            if (releaseModeType == null) {
+                result.success(false)
+                return
+            }
+
             releaseModeType?.let {
                 when (releaseModeType) {
                     0 -> {
@@ -209,6 +214,7 @@ class AudioPlayer(
                 }
             }
 
+            result.success(true)
         } catch (e: Exception) {
             result.error(Constants.LOG_TAG, "Can not set the release mode", e.toString())
         }

--- a/ios/Classes/AudioPlayer.swift
+++ b/ios/Classes/AudioPlayer.swift
@@ -147,7 +147,7 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
         }else{
             self.finishMode = FinishMode.stop
         }
-        result(nil)
+        result(true)
     }
 
     func startListening() {

--- a/ios/Classes/AudioPlayer.swift
+++ b/ios/Classes/AudioPlayer.swift
@@ -147,6 +147,7 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
         }else{
             self.finishMode = FinishMode.stop
         }
+        result(nil)
     }
 
     func startListening() {


### PR DESCRIPTION
Async method channel calls should return result every time, otherwise they hang when you try to await them. 