### PR TITLE
fix: 🐛 Fix calling preparePlayer again does not cancel old waveform extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0 (Unreleased)
+
+- Fixed [#350](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/350) - Left most visible wave is clipped in half when recording.
+- **BREAKING:** Fixed [#412](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/412) - Calling preparePlayer again does not cancel old waveform extraction.
+
 ## 1.3.0
 
 - Fixed [#386](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/386) - On permission denied isRecording flag changed

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -38,8 +38,10 @@ class AudioPlayer(
             }
             val uri = Uri.parse(path)
             val mediaItem = MediaItem.fromUri(uri)
+            stop()
+            player?.clearMediaItems()
             player = ExoPlayer.Builder(appContext).build()
-            player?.addMediaItem(mediaItem)
+            player?.setMediaItem(mediaItem)
             player?.prepare()
             playerListener = object : Player.Listener {
 

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioWaveformsPlugin.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioWaveformsPlugin.kt
@@ -268,7 +268,7 @@ class AudioWaveformsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun initPlayer(playerKey: String) {
-        if (audioPlayers[playerKey] == null) {
+        if (!audioPlayers.containsKey(playerKey)) {
             val newPlayer = AudioPlayer(
                 context = applicationContext,
                 channel = channel,
@@ -289,6 +289,7 @@ class AudioWaveformsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             result.error(Constants.LOG_TAG, "Path can't be null", "")
             return
         }
+        extractors[playerKey]?.stop()
         extractors[playerKey] = WaveformExtractor(
             context = applicationContext,
             methodChannel = channel,
@@ -306,7 +307,6 @@ class AudioWaveformsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
         )
         extractors[playerKey]?.startDecode()
-        extractors[playerKey]?.stop()
     }
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {

--- a/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
@@ -28,8 +28,6 @@ class WaveformExtractor(
     private var progress = 0F
     private var currentProgress = 0F
 
-    @Volatile
-    private var started = false
     private val finishCount = CountDownLatch(1)
     private var inputEof = false
     private var sampleRate = 0
@@ -234,8 +232,6 @@ class WaveformExtractor(
     }
 
     fun stop() {
-        if (!started) return
-        started = false
         decoder?.stop()
         decoder?.release()
         extractor?.release()

--- a/ios/Classes/AudioPlayer.swift
+++ b/ios/Classes/AudioPlayer.swift
@@ -29,6 +29,8 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
                 return
             }
             do {
+                stopPlayer()
+                player = nil
                 player = try AVAudioPlayer(contentsOf: audioUrl!)
                 do {
                     if overrideAudioSession {


### PR DESCRIPTION
This PR fixes #412