### PR TITLE
 Fix URL Audio Playback by Preserving Full URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Widget build(BuildContext context) {
 2. Loading from device storage
    - When you load a file from device storage, they are already in the memory so you can directly set the file path.    
 3. Loading from network
-   - Currently playing remote audio file isn't supported so first you will need to download it and then you can play it.  
+   - Just pass the URL. But make sure its HTTPs otherwise it will cause Cleartext HTTP traffic error.  
 4. Deciding if waveforms should be extracted with the preparePlayer
    ```dart
    playerController.preparePlayer(shouldExtractWaveform: true);

--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -130,7 +130,10 @@ class PlayerController extends ChangeNotifier {
     bool shouldExtractWaveform = true,
     int noOfSamples = 100,
   }) async {
-    //path = Uri.parse(path).path;//don't need this as it will break the url structure expected by Exoplayer
+    if (!path.startsWith('http://') || !path.startsWith('https://')) {
+      // Keep the full URL for remote files and strip for local files
+      path = Uri.parse(path).path;
+    }
     final isPrepared = await AudioWaveformsInterface.instance.preparePlayer(
       path: path,
       key: playerKey,

--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -130,7 +130,7 @@ class PlayerController extends ChangeNotifier {
     bool shouldExtractWaveform = true,
     int noOfSamples = 100,
   }) async {
-    path = Uri.parse(path).path;
+    //path = Uri.parse(path).path;//don't need this as it will break the url structure expected by Exoplayer
     final isPrepared = await AudioWaveformsInterface.instance.preparePlayer(
       path: path,
       key: playerKey,

--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -130,7 +130,7 @@ class PlayerController extends ChangeNotifier {
     bool shouldExtractWaveform = true,
     int noOfSamples = 100,
   }) async {
-    if (!path.startsWith('http://') || !path.startsWith('https://')) {
+    if (!path.startsWith('http')) {
       // Keep the full URL for remote files and strip for local files
       path = Uri.parse(path).path;
     }


### PR DESCRIPTION

## Problem
The `preparePlayer` method was incorrectly stripping the protocol and domain from URLs, causing remote audio files to fail with "file not found" errors.

**Before:**
```dart
path = Uri.parse(path).path;
```

When passing `"https://example.com/uploads/audio.m4a"`, this would extract only `"/uploads/audio.m4a"`, causing ExoPlayer to treat it as a local file path instead of a URL.

## Solution
Modified the path processing logic to preserve full URLs for remote files while maintaining existing behavior for local files.

**After:**
```dart
 if (!path.startsWith('http') ) {
      // Keep the full URL for remote files and strip for local files
      path = Uri.parse(path).path;
    }
```

## Changes
- Updated `preparePlayer` method to conditionally process paths
- Remote URLs (http/https) are preserved as-is
- Local file paths continue to use `Uri.parse(path).path` for normalization
- No breaking changes to existing local file functionality

## Testing
- ✅ Local audio files continue to work as before
- ✅ HTTP/HTTPS URLs now work correctly
- ✅ No regression in existing functionality

## Impact
This fix enables proper playback of remote audio files without affecting local file playback behavior.