### PR TITLE
fix: 🐛Waveform extraction is not cancel when PlayerController is disposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed [#464](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/464) - Fixed labels not displaying properly during recording
 - Feature [#398](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/398) - Add noOfSamplesPerSecond parameter to preparePlayer for easier waveform configuration
 - Fixed [#441](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/441) - Incorrect waveform UI when setting `Duration.zero` for AudioFileWaveforms
+- Fixed [#439](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/439) - Waveform extraction is not cancel when PlayController is disposed
 
 ## 2.0.1
 

--- a/lib/src/controllers/player_controller.dart
+++ b/lib/src/controllers/player_controller.dart
@@ -317,6 +317,7 @@ class PlayerController extends ChangeNotifier {
   void dispose() async {
     if (playerState != PlayerState.stopped) await stopPlayer();
     await release();
+    await waveformExtraction.stopWaveformExtraction();
     PlatformStreams.instance.playerControllerFactory.remove(playerKey);
     if (PlatformStreams.instance.playerControllerFactory.isEmpty) {
       PlatformStreams.instance.dispose();


### PR DESCRIPTION
Fixes #439 