### PR TITLE
fix: 🔨 Fixed labels not displaying properly during recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.0.2 (#unreleased)
 
-- Chore [#461](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/461) - Update analysis options and related files
 - Chore [#460](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/460) - Update compileSdk and targetSdk to run example app
+- Chore [#461](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/461) - Update analysis options and related files
+- Fixed [#464](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/464) - Fixed labels not displaying properly during recording
 
 ## 2.0.1
 

--- a/lib/src/audio_waveforms.dart
+++ b/lib/src/audio_waveforms.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '/audio_waveforms.dart';
+import 'base/label.dart';
 import 'base/wave_clipper.dart';
 import 'painters/recorder_wave_painter.dart';
 
@@ -37,6 +38,7 @@ class AudioWaveforms extends StatefulWidget {
 class _AudioWaveformsState extends State<AudioWaveforms> {
   bool _isScrolled = false;
 
+  /// Tracks the total horizontal offset applied when the waveform is shifted backward.
   Offset _totalBackDistance = Offset.zero;
   Offset _dragOffset = Offset.zero;
 
@@ -45,20 +47,53 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
   Duration currentlyRecordedDuration = Duration.zero;
   late StreamSubscription<Duration> streamSubscription;
 
+  late final Size _size;
+  late final WaveStyle _waveStyle;
+  late final RecorderController _recorderController;
+
+  /// Duration timestamp labels shown on the waveform, added every second during recording.
+  final List<Label> _labels = [];
+
   @override
   void initState() {
     super.initState();
-    _initialPosition = -(widget.waveStyle.waveThickness / 2);
-    widget.recorderController.addListener(_recorderControllerListener);
+    _size = widget.size;
+    _waveStyle = widget.waveStyle;
+    _recorderController = widget.recorderController;
+    _initialPosition = -(_waveStyle.waveThickness / 2);
+    _recorderController.addListener(_recorderControllerListener);
     streamSubscription =
-        widget.recorderController.onCurrentDuration.listen((duration) {
+        _recorderController.onCurrentDuration.listen((duration) {
       currentlyRecordedDuration = duration;
+      final currentSeconds = currentlyRecordedDuration.inSeconds;
+      if (currentSeconds > 0 && _labels.length < currentSeconds) {
+        _labels.add(
+          Label(
+            content: _waveStyle.showHourInDuration
+                ? Duration(seconds: currentSeconds).toHHMMSS()
+                : currentSeconds.toMMSS(),
+            // Calculate label position based on current waveform length
+            // X-axis: Position label at the end of the waveform
+            //         (spacing × number of wave bars = total waveform width)
+            // Y-axis: Position below the waveform container
+            //         (container height + line height = below the waveform)
+            offset: Offset(
+              _waveStyle.spacing * _recorderController.waveData.length,
+              _size.height + _waveStyle.durationLinesHeight,
+            ),
+          ),
+        );
+        // Only trigger UI rebuild if widget is still in the tree
+        if (mounted) {
+          setState(() {});
+        }
+      }
     });
   }
 
   @override
   void dispose() {
-    widget.recorderController.removeListener(_recorderControllerListener);
+    _recorderController.removeListener(_recorderControllerListener);
     streamSubscription.cancel();
     super.dispose();
   }
@@ -82,42 +117,41 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
           ),
           child: RepaintBoundary(
             child: CustomPaint(
-              size: widget.size,
+              size: _size,
               painter: RecorderWavePainter(
-                waveThickness: widget.waveStyle.waveThickness,
-                middleLineThickness: widget.waveStyle.middleLineThickness,
-                middleLineColor: widget.waveStyle.middleLineColor,
-                waveData: widget.recorderController.waveData,
-                callPushback: widget.recorderController.shouldRefresh,
-                bottomPadding:
-                    widget.waveStyle.bottomPadding ?? widget.size.height / 2,
-                spacing: widget.waveStyle.spacing,
-                waveCap: widget.waveStyle.waveCap,
-                showBottom: widget.waveStyle.showBottom,
-                showTop: widget.waveStyle.showTop,
-                waveColor: widget.waveStyle.waveColor,
-                showMiddleLine: widget.waveStyle.showMiddleLine,
-                totalBackDistance: _totalBackDistance,
+                labels: _labels,
+                waveThickness: _waveStyle.waveThickness,
+                middleLineThickness: _waveStyle.middleLineThickness,
+                middleLineColor: _waveStyle.middleLineColor,
+                waveData: _recorderController.waveData,
+                callPushback: _recorderController.shouldRefresh,
+                bottomPadding: _waveStyle.bottomPadding ?? _size.height / 2,
+                spacing: _waveStyle.spacing,
+                waveCap: _waveStyle.waveCap,
+                showBottom: _waveStyle.showBottom,
+                showTop: _waveStyle.showTop,
+                waveColor: _waveStyle.waveColor,
+                showMiddleLine: _waveStyle.showMiddleLine,
+                totalCurrentBackDistance: _totalBackDistance,
                 dragOffset: _dragOffset,
                 pushBack: _pushBackWave,
                 initialPosition: _initialPosition,
-                extendWaveform: widget.waveStyle.extendWaveform,
-                showHourInDuration: widget.waveStyle.showHourInDuration,
-                showDurationLabel: widget.waveStyle.showDurationLabel,
-                durationLinesColor: widget.waveStyle.durationLinesColor,
-                durationStyle: widget.waveStyle.durationStyle,
-                durationTextPadding: widget.waveStyle.durationTextPadding,
-                durationLinesHeight: widget.waveStyle.durationLinesHeight,
-                labelSpacing: widget.waveStyle.labelSpacing,
-                gradient: widget.waveStyle.gradient,
-                shouldClearLabels: widget.recorderController.shouldClearLabels,
-                revertClearLabelCall:
-                    widget.recorderController.revertClearLabelCall,
+                extendWaveform: _waveStyle.extendWaveform,
+                showHourInDuration: _waveStyle.showHourInDuration,
+                showDurationLabel: _waveStyle.showDurationLabel,
+                durationLinesColor: _waveStyle.durationLinesColor,
+                durationStyle: _waveStyle.durationStyle,
+                durationTextPadding: _waveStyle.durationTextPadding,
+                durationLinesHeight: _waveStyle.durationLinesHeight,
+                labelSpacing: _waveStyle.labelSpacing,
+                gradient: _waveStyle.gradient,
+                shouldClearLabels: _recorderController.shouldClearLabels,
+                revertClearLabelCall: _recorderController.revertClearLabelCall,
                 setCurrentPositionDuration:
-                    widget.recorderController.setScrolledPositionDuration,
+                    _recorderController.setScrolledPositionDuration,
                 shouldCalculateScrolledPosition:
                     widget.shouldCalculateScrolledPosition,
-                scaleFactor: widget.waveStyle.scaleFactor,
+                scaleFactor: _waveStyle.scaleFactor,
                 currentlyRecordedDuration: currentlyRecordedDuration,
               ),
             ),
@@ -128,22 +162,20 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
   }
 
   /// Gets width of a single wave including space between two waves.
-  double get _waveWidth =>
-      widget.waveStyle.waveThickness + widget.waveStyle.spacing;
+  double get _waveWidth => _waveStyle.waveThickness + _waveStyle.spacing;
 
   /// Provides extra clipping if needed.
   double get _extraClipperHeight {
-    if (widget.waveStyle.showDurationLabel) {
+    if (_waveStyle.showDurationLabel) {
       // If duration labels are enabled and for some reason labels are getting
       // cut or effecting other widget cut. This will help to reduce or add
       // clipping.
-      if (widget.waveStyle.extraClipperHeight != null) {
-        return widget.waveStyle.extraClipperHeight!;
+      if (_waveStyle.extraClipperHeight != null) {
+        return _waveStyle.extraClipperHeight!;
       }
       // Default clipping. Calculated from duration line.
-      return widget.waveStyle.durationLinesHeight +
-          (widget.waveStyle.durationStyle.fontSize ??
-              widget.waveStyle.durationLinesHeight);
+      return _waveStyle.durationLinesHeight +
+          (_waveStyle.durationStyle.fontSize ?? _waveStyle.durationLinesHeight);
     } else {
       // If labels are disabled then there is no need to add/remove extra
       // clipping.
@@ -154,12 +186,12 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
   ///This handles scrolling of the wave
   void _handleHorizontalDragUpdate(DragUpdateDetails details) {
     var direction = details.globalPosition.dx - _initialOffsetPosition;
-    widget.recorderController.setRefresh(false);
+    _recorderController.setRefresh(false);
     _isScrolled = true;
 
     ///left to right
     if (-_totalBackDistance.dx + _dragOffset.dx + details.delta.dx <
-            (widget.size.width / 2) &&
+            (_size.width / 2) &&
         direction > 0) {
       setState(() => _dragOffset += details.delta);
     }
@@ -167,10 +199,9 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
     ///right to left
     else if (-_totalBackDistance.dx +
                 _dragOffset.dx +
-                (widget.waveStyle.spacing *
-                    widget.recorderController.waveData.length) +
+                (_waveStyle.spacing * _recorderController.waveData.length) +
                 details.delta.dx >
-            (widget.size.width / 2) &&
+            (_size.width / 2) &&
         direction < 0) {
       setState(() => _dragOffset += details.delta);
     }
@@ -188,17 +219,15 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
   void _pushBackWave() {
     if (_isScrolled) {
       _initialPosition =
-          widget.waveStyle.spacing * widget.recorderController.waveData.length -
-              widget.size.width / 2;
-      _totalBackDistance =
-          _totalBackDistance + Offset(widget.waveStyle.spacing, 0.0);
+          _waveStyle.spacing * _recorderController.waveData.length -
+              _size.width / 2;
+      _totalBackDistance = _totalBackDistance + Offset(_waveStyle.spacing, 0.0);
       _isScrolled = false;
     } else {
       _initialPosition = 0.0;
-      _totalBackDistance =
-          _totalBackDistance + Offset(widget.waveStyle.spacing, 0.0);
+      _totalBackDistance = _totalBackDistance + Offset(_waveStyle.spacing, 0.0);
     }
-    if (widget.recorderController.shouldClearLabels) {
+    if (_recorderController.shouldClearLabels) {
       _initialOffsetPosition = 0.0;
       _totalBackDistance = Offset.zero;
       _dragOffset = Offset.zero;
@@ -206,8 +235,13 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
   }
 
   void _recorderControllerListener() {
-    if (mounted) {
-      setState(() {});
-    }
+    if (!mounted) return;
+
+    // Only call setState if labels actually need to be cleared
+    setState(() {
+      if (_recorderController.shouldClearLabels) {
+        _labels.clear();
+      }
+    });
   }
 }


### PR DESCRIPTION
### 🐞 Issue Description
**Label not printing properly during recording.**  
It appears overlapped at the initial stage and then displays correctly afterward after fixed.

---

### 🎥 Comparison

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/d6647369-8fba-4d5a-a772-591e039ccf71" height="350" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/2d65033a-2c8e-43b3-80a9-ba38361e4635" height="350" controls></video>
    </td>
  </tr>
</table>
