### PR TITLE
fix:🐛Recorded duration is not same as controller duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature [#398](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/398) - Add noOfSamplesPerSecond parameter to preparePlayer for easier waveform configuration
 - Fixed [#441](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/441) - Incorrect waveform UI when setting `Duration.zero` for AudioFileWaveforms
 - Fixed [#439](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/439) - Waveform extraction is not cancel when PlayController is disposed
+- Fixed [#236](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/236) - Recorded duration is not same as controller duration
 
 ## 2.0.1
 

--- a/android/src/main/kotlin/com/simform/audio_waveforms/Utils.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/Utils.kt
@@ -71,6 +71,11 @@ object Constants {
     const val resultFilePath = "resultFilePath"
     const val resultDuration = "resultDuration"
     const val pauseAllPlayers = "pauseAllPlayers"
+    const val normalisedRms = "normalisedRms"
+    const val bytes = "bytes"
+    const val recordedDuration = "recordedDuration"
+    const val onAudioChunk = "onAudioChunk"
+
     // TODO: make user can set this in future
     const val CHANNEL: Int = 1
     const val BIT_PER_SAMPLE: Int = 16
@@ -87,6 +92,7 @@ object Constants {
     const val THIRTY_TWO_BITS = 2.14748365E9f
     const val ENCODER_THREAD = "EncoderThread"
     const val AAC_FILE_EXTENSION = "aac"
+    const val DEFAULT_SAMPLE_RATE = 44100
 }
 
 /**

--- a/ios/Classes/AudioRecorder.swift
+++ b/ios/Classes/AudioRecorder.swift
@@ -63,7 +63,11 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
             audioRecorder?.delegate = self
             audioRecorder?.isMeteringEnabled = true
             audioRecorder?.record()
-            bytesStreamEngine.attach(result: result)
+            bytesStreamEngine
+                .attach(
+                    result: result,
+                    sampleRate:  recordingSettings.sampleRate ?? Constants.defaultSampleRate
+                )
             result(true)
         } catch {
             result(FlutterError(code: Constants.audioWaveforms, message: "Failed to start recording", details: error.localizedDescription))

--- a/ios/Classes/Utils.swift
+++ b/ios/Classes/Utils.swift
@@ -71,6 +71,8 @@ struct Constants {
     static let onAudioChunk = "onAudioChunk"
     static let bytes = "bytes"
     static let normalisedRms = "normalisedRms"
+    static let recordedDuration = "recordedDuration"
+    static let defaultSampleRate = 44100
 }
 
 

--- a/lib/src/base/audio_waveforms_interface.dart
+++ b/lib/src/base/audio_waveforms_interface.dart
@@ -241,11 +241,15 @@ class AudioWaveformsInterface {
         case Constants.onAudioChunk:
           final normalisedRms = call.arguments[Constants.normalisedRms];
           final bytes = call.arguments[Constants.bytes];
+          final recordedDuration = call.arguments[Constants.recordedDuration];
           if (normalisedRms is double) {
             instance.addAmplitudeEvent(normalisedRms);
           }
           if (bytes is Uint8List) {
             instance.addRecordedBytes(bytes);
+          }
+          if (recordedDuration is int) {
+            instance.addRecordedDurationEvent(recordedDuration);
           }
           break;
       }

--- a/lib/src/base/constants.dart
+++ b/lib/src/base/constants.dart
@@ -58,4 +58,5 @@ class Constants {
   static const String onAudioChunk = 'onAudioChunk';
   static const String normalisedRms = 'normalisedRms';
   static const String bytes = 'bytes';
+  static const String recordedDuration = 'recordedDuration';
 }

--- a/lib/src/base/platform_streams.dart
+++ b/lib/src/base/platform_streams.dart
@@ -36,6 +36,7 @@ class PlatformStreams {
         StreamController<PlayerIdentifier<void>>.broadcast();
     _recordingAmplitudeController = StreamController<double>.broadcast();
     _recordedBytesController = StreamController<Uint8List>.broadcast();
+    _recordedDurationController = StreamController<Duration>.broadcast();
     await AudioWaveformsInterface.instance.setMethodCallHandler();
   }
 
@@ -55,7 +56,10 @@ class PlatformStreams {
       _completionController.stream;
 
   Stream<double> get onAmplitude => _recordingAmplitudeController.stream;
+
   Stream<Uint8List> get onRecordedBytes => _recordedBytesController.stream;
+
+  Stream<Duration> get onCurrentDuration => _recordedDurationController.stream;
 
   late StreamController<PlayerIdentifier<int>> _currentDurationController;
   late StreamController<PlayerIdentifier<PlayerState>> _playerStateController;
@@ -65,6 +69,7 @@ class PlatformStreams {
   late StreamController<PlayerIdentifier<void>> _completionController;
   late StreamController<double> _recordingAmplitudeController;
   late StreamController<Uint8List> _recordedBytesController;
+  late StreamController<Duration> _recordedDurationController;
 
   void addCurrentDurationEvent(PlayerIdentifier<int> playerIdentifier) {
     if (!_currentDurationController.isClosed) {
@@ -108,6 +113,11 @@ class PlatformStreams {
     _recordedBytesController.add(event);
   }
 
+  void addRecordedDurationEvent(int milliSeconds) {
+    if (_recordedDurationController.isClosed) return;
+    _recordedDurationController.add(Duration(milliseconds: milliSeconds));
+  }
+
   void dispose() {
     _currentDurationController.close();
     _playerStateController.close();
@@ -115,6 +125,7 @@ class PlatformStreams {
     _completionController.close();
     _recordingAmplitudeController.close();
     _recordedBytesController.close();
+    _recordedDurationController.close();
     AudioWaveformsInterface.instance.removeMethodCallHandler();
     isInitialised = false;
   }


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

This PR improves upon reported recorded duration by removing static increment of 50 milliseconds and makes use of bytes written to file and sample rate.
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require audio_waveforms users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #236 
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
