### PR TITLE
fix: 🐛 Use hardware format when streaming bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed [#439](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/439) - Waveform extraction is not cancel when PlayController is disposed
 - Fixed [#236](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/236) - Recorded duration is not same as controller duration
 - Feature [#250](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/250) - Add support for right to left waveform rendering
+- Fixed [#463](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/463) - iOS crash while streaming audio bytes due to hardware format mismatch 
 
 ## 2.0.1
 

--- a/ios/Classes/RecorderBytesStreamEngine.swift
+++ b/ios/Classes/RecorderBytesStreamEngine.swift
@@ -11,7 +11,6 @@ import Accelerate
 
 class RecorderBytesStreamEngine {
     private var audioEngine = AVAudioEngine()
-    private var audioFormat: AVAudioFormat?
     private var flutterChannel: FlutterMethodChannel
     private var paused: Bool = false
     private var totalFrames: AVAudioFramePosition = 0
@@ -22,8 +21,7 @@ class RecorderBytesStreamEngine {
 
     func attach(result: @escaping FlutterResult, sampleRate: Int) {
         let inputNode = audioEngine.inputNode
-        audioFormat = inputNode.outputFormat(forBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: audioFormat) { (buffer, time) in
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { (buffer, time) in
             if self.paused {
                 return
             }


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
Use hardware format for bytes streaming to avoid mismatch with AVAudioEngine

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require audio_waveforms users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #463 
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
