### PR TITLE
fix: Inaccurate duration on Android

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
@@ -126,6 +126,7 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
             )
             return
         }
+        totalSamples = 0L
         audioRecord?.startRecording()
         recorderState = RecorderState.Recording
         if (encoder?.encodeForWav == true) {
@@ -153,7 +154,7 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
                             commonEncoder.queueInputBuffer(audioData)
                         }
                         val rms = calculateRms(audioData, read)
-                        totalSamples += read / channelCount
+                        totalSamples += (read / 2) / channelCount
                         val durationSec =
                             totalSamples.toDouble() / (recorderSettings?.sampleRate
                                 ?: Constants.DEFAULT_SAMPLE_RATE)
@@ -170,7 +171,6 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
     fun stop(result: Result) {
         try {
             audioRecord?.stop()
-            totalSamples = 0L
             recorderState = RecorderState.Stopped
             if (encoder?.encodeForWav == true) {
                 wavEncoder?.stop(result)


### PR DESCRIPTION

# Description
Resolves an issue where the recorded duration reported is twice the real value on Android.



## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require audio_waveforms users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

Closes https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/476


<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
