### PR TITLE
fix: Android recorderController.stop() never completes

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
@@ -176,18 +176,18 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
                 wavEncoder?.stop(result)
                 recordingThread?.join()
                 sendRecordingResult(result)
+                release()
             } else {
                 commonEncoder.setOnEncodingCompleted {
                     sendRecordingResult(result)
+                    release()
                 }
                 commonEncoder.signalToStop()
             }
-
         } catch (e: Exception) {
             result.error(LOG_TAG, e.message, "An error occurred while stopping the recorder")
-            return
+            release()
         }
-        release()
     }
 
     private fun sendRecordingResult(result: Result) {
@@ -195,7 +195,9 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
         val hashMap = HashMap<String, Any?>()
         hashMap[Constants.resultFilePath] = recorderSettings?.path
         hashMap[Constants.resultDuration] = duration
-        result.success(hashMap)
+        Handler(Looper.getMainLooper()).post {
+            result.success(hashMap)
+        }
     }
 
     private fun sendBytesToFlutter(chunk: ByteArray, rms: Double, milliSeconds: Long) {

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
@@ -39,6 +39,7 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
     private var wavEncoder: WavEncoder? = null
     private var successCallback: RequestPermissionsSuccessCallback? = null
     private var totalSamples = 0L
+    private val mainHandler = Handler(Looper.getMainLooper())
     private val channelCount: Int
         get() = when (channelConfig) {
             AudioFormat.CHANNEL_IN_MONO -> 1
@@ -195,7 +196,7 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
         val hashMap = HashMap<String, Any?>()
         hashMap[Constants.resultFilePath] = recorderSettings?.path
         hashMap[Constants.resultDuration] = duration
-        Handler(Looper.getMainLooper()).post {
+        mainHandler.post {
             result.success(hashMap)
         }
     }
@@ -205,7 +206,7 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
         args[Constants.normalisedRms] = rms
         args[Constants.bytes] = chunk
         args[Constants.recordedDuration] = milliSeconds
-        Handler(Looper.getMainLooper()).post {
+        mainHandler.post {
             channel.invokeMethod(Constants.onAudioChunk, args)
         }
     }

--- a/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
@@ -267,10 +267,11 @@ class CommonEncoder {
     fun signalToStop() {
         isEncodingComplete = true
 
-        // If an input buffer is already available and the queue is empty,
-        // the onInputBufferAvailable callback won't fire again on its own.
-        // We must queue the EOS buffer now to avoid hanging forever.
-        synchronized(inputQueue) {
+        // Post the EOS check to the handler thread so it runs on the same
+        // thread as onInputBufferAvailable, avoiding race conditions where
+        // both threads try to queue EOS with the same buffer index.
+        handler.post {
+            if (isEncoderStopped) return@post
             if (currentInputBufferIndex >= 0 && inputQueue.isEmpty()) {
                 try {
                     queueEosBuffer(mediaCodec, currentInputBufferIndex)
@@ -429,12 +430,14 @@ class CommonEncoder {
             mediaMuxer?.stop()
             mediaMuxer?.release()
             outputStream.close()
-            handlerThread.quitSafely()
-            handlerThread.join()
         } catch (e: Exception) {
             Log.e(Constants.LOG_TAG, "Error stopping encoder: ${e.message}")
         } finally {
             completionCallback?.invoke()
+            // Quit the handler thread after invoking the callback.
+            // Don't call join() -- stopEncoder() is called from callbacks
+            // running on this same thread, so joining would deadlock.
+            handlerThread.quitSafely()
         }
 
         // Reset state for next recording

--- a/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
@@ -55,15 +55,18 @@ class CommonEncoder {
     private val inputQueue = LinkedList<ByteArray>()
     
     /** Current available input buffer index (-1 if none available) */
+    @Volatile
     private var currentInputBufferIndex = -1
 
     /** Flag indicating if the muxer has been started */
     private var isMuxerStarted = false
     
     /** Flag indicating encoding process should complete */
+    @Volatile
     private var isEncodingComplete = false
-    
+
     /** Flag indicating encoder has been stopped */
+    @Volatile
     private var isEncoderStopped = false
     
     /** Track index for the audio track in the muxer */
@@ -73,6 +76,7 @@ class CommonEncoder {
     private var completionCallback: (() -> Unit)? = null
     
     /** Total bytes encoded so far, used for calculating presentation timestamps */
+    @Volatile
     private var totalBytesEncoded = 0L
     
     /** Track the first output timestamp to normalize subsequent timestamps */
@@ -152,6 +156,7 @@ class CommonEncoder {
 
         mediaCodec.setCallback(object : MediaCodec.Callback() {
             override fun onInputBufferAvailable(codec: MediaCodec, index: Int) {
+                if (isEncoderStopped) return
                 if (isEncodingComplete && inputQueue.isEmpty()) {
                     queueEosBuffer(codec, index)
                 } else {
@@ -280,6 +285,9 @@ class CommonEncoder {
                     Log.e(Constants.LOG_TAG, "Error queuing EOS in signalToStop: ${e.message}")
                 }
             }
+            // Otherwise EOS is queued by a later onInputBufferAvailable once
+            // the queue drains; if the codec never returns an input buffer,
+            // the completion callback (and the Dart stop() future) would hang.
         }
     }
 
@@ -322,25 +330,31 @@ class CommonEncoder {
      */
     private fun feedEncoder() {
         synchronized(inputQueue) {
+            if (isEncoderStopped) return
             if (inputQueue.isEmpty() || currentInputBufferIndex < 0) return
 
             val data = inputQueue.poll() ?: return
-            val inputBuffer = mediaCodec.getInputBuffer(currentInputBufferIndex) ?: return
-            inputBuffer.clear()
-            inputBuffer.put(data)
+            try {
+                val inputBuffer = mediaCodec.getInputBuffer(currentInputBufferIndex) ?: return
+                inputBuffer.clear()
+                inputBuffer.put(data)
 
-            // Calculate presentation time based on actual audio data encoded
-            // Formula: presentationTimeUs = (totalBytes * 1,000,000) / (sampleRate * channels * bytesPerSample)
-            // For 16-bit PCM mono: bytesPerSample = 2, channels = 1
-            val bytesPerSample = 2L  // 16-bit = 2 bytes
-            val channels = 1L  // Mono
-            val presentationTimeUs = (totalBytesEncoded * 1_000_000L) / (recorderSettings.sampleRate * channels * bytesPerSample)
-            totalBytesEncoded += data.size
-            
-            mediaCodec.queueInputBuffer(
-                currentInputBufferIndex, 0, data.size, presentationTimeUs, 0
-            )
-            currentInputBufferIndex = -1
+                // Calculate presentation time based on actual audio data encoded
+                // Formula: presentationTimeUs = (totalBytes * 1,000,000) / (sampleRate * channels * bytesPerSample)
+                // For 16-bit PCM mono: bytesPerSample = 2, channels = 1
+                val bytesPerSample = 2L  // 16-bit = 2 bytes
+                val channels = 1L  // Mono
+                val presentationTimeUs = (totalBytesEncoded * 1_000_000L) / (recorderSettings.sampleRate * channels * bytesPerSample)
+                totalBytesEncoded += data.size
+
+                mediaCodec.queueInputBuffer(
+                    currentInputBufferIndex, 0, data.size, presentationTimeUs, 0
+                )
+                currentInputBufferIndex = -1
+            } catch (e: IllegalStateException) {
+                // The codec may have been released by stopEncoder() on another thread.
+                Log.e(Constants.LOG_TAG, "Error feeding encoder: ${e.message}")
+            }
         }
     }
 
@@ -423,6 +437,11 @@ class CommonEncoder {
     private fun stopEncoder() {
         if (isEncoderStopped) return
         isEncoderStopped = true
+
+        // Purge queued messages so quitSafely() can't run them against a
+        // released codec. MediaCodec's own callback messages live on its
+        // internal handler, hence the isEncoderStopped guards elsewhere.
+        handler.removeCallbacksAndMessages(null)
 
         try {
             mediaCodec.stop()

--- a/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
@@ -153,17 +153,7 @@ class CommonEncoder {
         mediaCodec.setCallback(object : MediaCodec.Callback() {
             override fun onInputBufferAvailable(codec: MediaCodec, index: Int) {
                 if (isEncodingComplete && inputQueue.isEmpty()) {
-                    // Use the last calculated presentation time for EOF, not system time
-                    val eofTimestamp = if (totalBytesEncoded > 0) {
-                        val bytesPerSample = 2L
-                        val channels = 1L
-                        (totalBytesEncoded * 1_000_000L) / (recorderSettings.sampleRate * channels * bytesPerSample)
-                    } else {
-                        0L
-                    }
-                    codec.queueInputBuffer(
-                        index, 0, 0, eofTimestamp, MediaCodec.BUFFER_FLAG_END_OF_STREAM
-                    )
+                    queueEosBuffer(codec, index)
                 } else {
                     currentInputBufferIndex = index
                     feedEncoder()
@@ -244,7 +234,7 @@ class CommonEncoder {
                     isMuxerStarted = true
                 }
             }
-        })
+        }, handler)
 
         mediaCodec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
         mediaCodec.start()
@@ -276,6 +266,20 @@ class CommonEncoder {
      */
     fun signalToStop() {
         isEncodingComplete = true
+
+        // If an input buffer is already available and the queue is empty,
+        // the onInputBufferAvailable callback won't fire again on its own.
+        // We must queue the EOS buffer now to avoid hanging forever.
+        synchronized(inputQueue) {
+            if (currentInputBufferIndex >= 0 && inputQueue.isEmpty()) {
+                try {
+                    queueEosBuffer(mediaCodec, currentInputBufferIndex)
+                    currentInputBufferIndex = -1
+                } catch (e: Exception) {
+                    Log.e(Constants.LOG_TAG, "Error queuing EOS in signalToStop: ${e.message}")
+                }
+            }
+        }
     }
 
     /**
@@ -287,6 +291,22 @@ class CommonEncoder {
         completionCallback = callback
     }
 
+
+    /**
+     * Queues an end-of-stream buffer to signal that encoding is complete.
+     */
+    private fun queueEosBuffer(codec: MediaCodec, bufferIndex: Int) {
+        val eofTimestamp = if (totalBytesEncoded > 0) {
+            val bytesPerSample = 2L
+            val channels = 1L
+            (totalBytesEncoded * 1_000_000L) / (recorderSettings.sampleRate * channels * bytesPerSample)
+        } else {
+            0L
+        }
+        codec.queueInputBuffer(
+            bufferIndex, 0, 0, eofTimestamp, MediaCodec.BUFFER_FLAG_END_OF_STREAM
+        )
+    }
 
     /**
      * Feeds available audio data to the encoder
@@ -411,9 +431,10 @@ class CommonEncoder {
             outputStream.close()
             handlerThread.quitSafely()
             handlerThread.join()
-            completionCallback?.invoke()
         } catch (e: Exception) {
             Log.e(Constants.LOG_TAG, "Error stopping encoder: ${e.message}")
+        } finally {
+            completionCallback?.invoke()
         }
 
         // Reset state for next recording


### PR DESCRIPTION
# Description

  Fixes a hang where `await recorderController.stop()` on Android never completes, especially for recordings >30 seconds. This was introduced in the 2.0.x rewrite that replaced `MediaRecorder` with `AudioRecord` +
  `MediaCodec`.

  **Root causes fixed:**

  1. **Deadlock in `stopEncoder()`** — `stopEncoder()` is called from `onOutputBufferAvailable` on the handler thread, but it called `handlerThread.join()`, waiting for itself to finish. Removed the `join()` and
  use `quitSafely()` only.

  2. **Race condition in `signalToStop()`** — EOS buffer queuing now runs on the handler thread via `handler.post {}`, avoiding races with `onInputBufferAvailable` that caused "MediaCodec discarded an unknown
  buffer" errors.

  3. **`release()` called before async completion** — For the non-WAV path, `release()` was called synchronously after `signalToStop()`, before the completion callback fired. Moved `release()` into the completion
  callback.

  4. **`result.success()` called from wrong thread** — `sendRecordingResult()` now posts to the main looper, since Flutter's `MethodChannel.Result` must be called on the platform thread.

  5. **`completionCallback` swallowed on error** — Moved `completionCallback?.invoke()` to a `finally` block in `stopEncoder()` so the Flutter result is always resolved.

  6. **Missing handler in `setCallback()`** — `mediaCodec.setCallback()` now passes the `handler` so callbacks run on the intended `HandlerThread`.

  ## Checklist

  - [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
  - [x] I have followed the [Contributor Guide] when preparing my PR.
  - [ ] I have updated/added tests for ALL new/updated/fixed functionality.
  - [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
  - [x] I have updated/added relevant examples in `examples` or `docs`.

There's no test infrastructure in the project and the bug is a native Android threading issue that's difficult to unit test from Dart

  ## Breaking Change?

  - [ ] Yes, this PR is a breaking change.
  - [x] No, this PR is not a breaking change.

  ## Related Issues
 #470