### PR TITLE
fix: Update totalSamples calculation to account for bytes per sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
+- Fixed [#491](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/491) - Update totalSamples calculation to account for bytes per sample
 
 ## 2.0.2
 

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
@@ -45,6 +45,13 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
             AudioFormat.CHANNEL_IN_STEREO -> 2
             else -> 1
         }
+    private val bytesPerSample: Int
+        get() = when (audioFormat) {
+            AudioFormat.ENCODING_PCM_8BIT -> 1
+            AudioFormat.ENCODING_PCM_16BIT -> 2
+            AudioFormat.ENCODING_PCM_FLOAT -> 4
+            else -> 2
+        }
 
     override fun onRequestPermissionsResult(
         requestCode: Int, permissions: Array<out String>, grantResults: IntArray
@@ -153,7 +160,7 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
                             commonEncoder.queueInputBuffer(audioData)
                         }
                         val rms = calculateRms(audioData, read)
-                        totalSamples += read / channelCount
+                        totalSamples += read / (channelCount * bytesPerSample)
                         val durationSec =
                             totalSamples.toDouble() / (recorderSettings?.sampleRate
                                 ?: Constants.DEFAULT_SAMPLE_RATE)


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
Before:

https://github.com/user-attachments/assets/69487016-882b-476a-95c7-cfaa5575edde

After:

https://github.com/user-attachments/assets/09b34729-2473-4bf7-b54a-eed9f8558093
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require audio_waveforms users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.





## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #491 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
