### PR TITLE
fix: 🐛 Prevent `nullptr == Tap()` crash on iOS during recorder stream start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
+- Fixed [#487](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/487) - iOS crash `nullptr == Tap()` when starting bytes streaming with a stale/leaked input tap
 
 ## 2.0.2
 

--- a/ios/Classes/RecorderBytesStreamEngine.swift
+++ b/ios/Classes/RecorderBytesStreamEngine.swift
@@ -21,6 +21,17 @@ class RecorderBytesStreamEngine {
 
     func attach(result: @escaping FlutterResult, sampleRate: Int) {
         let inputNode = audioEngine.inputNode
+
+        // Reset any previous engine/tap state before installing a new tap.
+        // Installing a tap on a bus that already has one throws a fatal
+        // `nullptr == Tap()` exception (see issue #487). This also cleans up
+        // a tap leaked when a prior `audioEngine.start()` failed.
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        inputNode.removeTap(onBus: 0)
+        totalFrames = 0
+
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { (buffer, time) in
             if self.paused {
                 return
@@ -40,6 +51,9 @@ class RecorderBytesStreamEngine {
         do {
             try audioEngine.start()
         } catch {
+           // Remove the tap so a failed start doesn't leak it onto the bus,
+           // which would crash the next `attach` with `nullptr == Tap()`.
+           inputNode.removeTap(onBus: 0)
            result(FlutterError(code: Constants.audioWaveforms, message: "Error starting Audio Engine", details: error.localizedDescription))
         }
     }


### PR DESCRIPTION
# Description

On iOS, starting the recorder bytes stream could crash with a fatal
`nullptr == Tap()` exception (issue #487).

`RecorderBytesStreamEngine.attach()` installed a tap on input bus 0 without
clearing any existing tap first. Two paths left a stale tap on the bus:

1. A second `attach()` call before `detach()` (re-start without teardown).
2. A prior `audioEngine.start()` that threw — the tap was installed but never
   removed, leaking it onto the bus.

`AVAudioEngine` throws `nullptr == Tap()` when a tap is installed on a bus that
already has one, crashing the app.

This PR makes `attach()` reset prior state before installing:
- Stops the engine if running, removes any existing tap on bus 0, and resets
  `totalFrames`.
- On a failed `audioEngine.start()`, removes the just-installed tap so it
  doesn't leak onto the bus and crash the next `attach()`.

No public API change.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #487

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
