### PR TITLE
fix: 🐛 Prevent Android recorder crash from stopping unstarted muxer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
+- Fixed [#482](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/482) - Prevent Android crash on stop by checking muxer state before stopping
 
 ## 2.0.2
 

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioRecorder.kt
@@ -135,15 +135,21 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
             )
             wavEncoder?.start(result)
         } else {
-            commonEncoder.initCodec(recorderSettings = recorderSettings!!, result = result) {
-                recordingThread?.join()
-            }
+            commonEncoder.initCodec(recorderSettings = recorderSettings!!, result = result)
         }
         val buffer = ByteArray(bufferSize!!)
         recordingThread = Thread {
             while (recorderState == RecorderState.Recording || recorderState == RecorderState.Paused) {
                 if (recorderState == RecorderState.Recording) {
                     val read = audioRecord?.read(buffer, 0, buffer.size) ?: 0
+
+                    if (read < 0) {
+                        // Negative return is an AudioRecord error (e.g. ERROR_INVALID_OPERATION,
+                        // ERROR_DEAD_OBJECT). Reading again would keep failing, so stop cleanly.
+                        Log.e(LOG_TAG, "AudioRecord.read() error: $read")
+                        recorderState = RecorderState.Stopped
+                        break
+                    }
 
                     if (read > 0) {
                         val audioData = buffer.copyOf(read)
@@ -169,12 +175,15 @@ class AudioRecorder : PluginRegistry.RequestPermissionsResultListener {
 
     fun stop(result: Result) {
         try {
-            audioRecord?.stop()
-            totalSamples = 0L
+            // Stop the read loop first, then unblock and join the recording thread so it
+            // can never call audioRecord.read() after the AudioRecord is released below.
             recorderState = RecorderState.Stopped
+            audioRecord?.stop()
+            recordingThread?.join()
+            recordingThread = null
+            totalSamples = 0L
             if (encoder?.encodeForWav == true) {
                 wavEncoder?.stop(result)
-                recordingThread?.join()
                 sendRecordingResult(result)
             } else {
                 commonEncoder.setOnEncodingCompleted {

--- a/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/encoders/CommonEncoder.kt
@@ -406,7 +406,11 @@ class CommonEncoder {
         try {
             mediaCodec.stop()
             mediaCodec.release()
-            mediaMuxer?.stop()
+            // Only stop the muxer if it was actually started; stopping an unstarted muxer
+            // throws and triggers the native MPEG4Writer "track not started" crash.
+            if (isMuxerStarted) {
+                mediaMuxer?.stop()
+            }
             mediaMuxer?.release()
             outputStream.close()
             handlerThread.quitSafely()


### PR DESCRIPTION
# Description

Fixes an Android-only native crash that occurs when recording is stopped before the muxer has started writing any track, plus two related race/error-handling issues in the recording thread.

**Existing behavior:** When `stop()` was called shortly after `start()` (i.e. before the `MediaMuxer` received its first frame and was started), the encoder unconditionally called `mediaMuxer?.stop()`. Stopping a muxer that was never started throws and triggers the native `MPEG4Writer` "track not started" crash, taking down the app.

Two further problems made this worse:
- The recording thread could call `audioRecord.read()` after the `AudioRecord` was released during `stop()`, because the read loop was not guaranteed to be stopped and joined before release.
- `AudioRecord.read()` errors (negative return values such as `ERROR_INVALID_OPERATION` / `ERROR_DEAD_OBJECT`) were ignored, so the loop kept retrying a failing read.

**Changes:**
- `CommonEncoder.kt` — guard `mediaMuxer?.stop()` with the existing `isMuxerStarted` flag so an unstarted muxer is only released, never stopped.
- `AudioRecorder.kt` — in `stop()`, set `RecorderState.Stopped` and join the recording thread *before* releasing `AudioRecord`, so the read loop can never touch a released object.
- `AudioRecorder.kt` — bail out of the read loop on a negative `read()` result instead of spinning on a permanently failing read.
- Removed the redundant `recordingThread?.join()` callback passed into `initCodec` (join is now handled centrally in `stop()`).

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #482

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
