### PR TITLE
fix: 🐛 Finalize iOS recording before returning path; fix file:// URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
-- Fixed [#432](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/432) - iOS kAudioFileInvalidFileError: finalise the recording before returning its path, and parse `file://` player paths correctly
+- Fixed [#432](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/432) - iOS kAudioFileInvalidFileError: finalise recording before returning path, handle re-entrant `stop()`, and parse `file://` player paths
+- Fixed player paths  `file://` parsing on macOS
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
+- Fixed [#432](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/432) - iOS kAudioFileInvalidFileError: finalise the recording before returning its path, and parse `file://` player paths correctly
 
 ## 2.0.2
 

--- a/ios/Classes/AudioPlayer.swift
+++ b/ios/Classes/AudioPlayer.swift
@@ -23,15 +23,24 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
     func preparePlayer(path: String?, volume: Double?, updateFrequency: Int?,result: @escaping FlutterResult, overrideAudioSession : Bool) {
         if(!(path ?? "").isEmpty) {
             self.updateFrequency = updateFrequency ?? 200
-            let audioUrl = URL.init(string: path!)
-            if(audioUrl == nil){
-                result(FlutterError(code: Constants.audioWaveforms, message: "Failed to initialise Url from provided audio file", details: "If path contains `file://` try removing it"))
-                return
+            // `URL(string:)` mis-parses raw paths and truncates `file://` URLs at
+            // `#`/`?`, so strip the scheme and percent-decode for `fileURLWithPath:`.
+            let audioUrl: URL
+            if path!.hasPrefix("file://") {
+                var stripped = String(path!.dropFirst("file://".count))
+                // `file:///path` starts with `/`; `file://host/path` keeps a host
+                // segment — drop it so the host isn't folded into the file path.
+                if !stripped.hasPrefix("/"), let slash = stripped.firstIndex(of: "/") {
+                    stripped = String(stripped[slash...])
+                }
+                audioUrl = URL(fileURLWithPath: stripped.removingPercentEncoding ?? stripped)
+            } else {
+                audioUrl = URL(fileURLWithPath: path!)
             }
             do {
                 stopPlayer()
                 player = nil
-                player = try AVAudioPlayer(contentsOf: audioUrl!)
+                player = try AVAudioPlayer(contentsOf: audioUrl)
                 do {
                     if overrideAudioSession {
                         try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)

--- a/ios/Classes/AudioRecorder.swift
+++ b/ios/Classes/AudioRecorder.swift
@@ -6,7 +6,14 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
     var path: String?
     var useLegacyNormalization: Bool = false
     var audioUrl: URL?
-    var recordedDuration: CMTime = CMTime.zero
+    /// Held until `audioRecorderDidFinishRecording` fires so we only read the
+    /// file and return its path once the recorder has finalised it on disk.
+    /// Re-entrant stops queue here and all resolve with the same result, so a
+    /// second `stop()` never gets an empty map / null path.
+    private var stopResults: [FlutterResult] = []
+    /// Bumped on every async stop; the watchdog bails if superseded, so a stale
+    /// timer can't consume a later recording's `stopResults`.
+    private var stopGeneration: Int = 0
     var flutterChannel: FlutterMethodChannel
     var bytesStreamEngine: RecorderBytesStreamEngine
     init(channel: FlutterMethodChannel){
@@ -75,36 +82,94 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
     }
     
     public func stopRecording(_ result: @escaping FlutterResult) {
-        audioRecorder?.stop()
+        // A stop is already in flight: queue this result so it resolves with the
+        // same finalised path/duration instead of getting an empty map / null path.
+        if !stopResults.isEmpty {
+            stopResults.append(result)
+            return
+        }
         bytesStreamEngine.detach()
-        if(audioUrl != nil) {
-            let asset = AVURLAsset(url:  audioUrl!)
-            
-            if #available(iOS 15.0, *) {
-                Task {
-                    do {
-                        recordedDuration = try await asset.load(.duration)
-                        sendResult(result, duration: Int(recordedDuration.seconds * 1000))
-                    } catch let err {
-                        debugPrint(err.localizedDescription)
-                        sendResult(result, duration: Int(CMTime.zero.seconds))
-                    }
+        // `stop()` finalises the file async; reading it early yields a truncated
+        // container. Defer to the delegate; finalise now only if recorder is gone.
+        guard let recorder = audioRecorder else {
+            finalizeRecording([result], url: audioUrl, path: path)
+            return
+        }
+        stopResults.append(result)
+        stopGeneration += 1
+        let generation = stopGeneration
+        // Detach so a subsequent `startRecording` can't mutate the URL/path this
+        // stop finalises; the watchdog closure keeps the recorder alive meanwhile.
+        audioRecorder = nil
+        recorder.stop()
+        // The delegate isn't guaranteed to fire, so force-finalise after a timeout
+        // or Dart's `stop()` hangs forever. `generation` guard + empty `stopResults`
+        // make a stale timer / the loser of delegate-vs-watchdog a no-op.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self = self,
+                  generation == self.stopGeneration,
+                  !self.stopResults.isEmpty else { return }
+            let pending = self.stopResults
+            self.stopResults = []
+            self.finalizeRecording(pending, url: recorder.url, path: recorder.url.path)
+        }
+    }
+
+    /// Reads the file's duration and returns its path; call only after writing
+    /// finished. URL/path passed in (not from `self`) to avoid a re-recording race.
+    /// All queued `results` resolve with the same path/duration.
+    private func finalizeRecording(_ results: [FlutterResult], url: URL?, path: String?) {
+        guard let url = url else {
+            sendResult(results, duration: 0, path: path)
+            return
+        }
+        let asset = AVURLAsset(url: url)
+        if #available(iOS 15.0, *) {
+            Task {
+                var durationMs = 0
+                do {
+                    let seconds = try await asset.load(.duration).seconds
+                    // `seconds` is NaN/infinite for an invalid or unfinished
+                    // container; `Int(NaN)` crashes, so only convert when finite.
+                    if seconds.isFinite { durationMs = Int(seconds * 1000) }
+                } catch let err {
+                    debugPrint(err.localizedDescription)
                 }
-            } else {
-                recordedDuration = asset.duration
-                sendResult(result, duration: Int(recordedDuration.seconds * 1000))
+                // FlutterResult must be invoked on the platform (main) thread;
+                // the Task continuation resumes on a background executor.
+                DispatchQueue.main.async {
+                    self.sendResult(results, duration: durationMs, path: path)
+                }
             }
         } else {
-            sendResult(result, duration: Int(CMTime.zero.seconds))
+            // `seconds` is NaN for an invalid container; `Int(NaN)` crashes.
+            let seconds = asset.duration.seconds
+            sendResult(results, duration: seconds.isFinite ? Int(seconds * 1000) : 0, path: path)
         }
-        audioRecorder = nil
     }
-    
-    private func sendResult(_ result: @escaping FlutterResult, duration:Int){
+
+    public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        // Hop to main: `stopResults`/`stopGeneration` are only mutated there and
+        // `FlutterResult` must run on the platform thread.
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, !self.stopResults.isEmpty else { return }
+            let results = self.stopResults
+            self.stopResults = []
+            // `flag == false`: recorder couldn't write a valid file. finalize still
+            // returns the path (zero duration) since Dart doesn't catch errors here.
+            if !flag {
+                debugPrint("audioRecorderDidFinishRecording reported failure for \(recorder.url)")
+            }
+            // Use the finishing recorder's own URL so a re-recording can't redirect us.
+            self.finalizeRecording(results, url: recorder.url, path: recorder.url.path)
+        }
+    }
+
+    private func sendResult(_ results: [FlutterResult], duration: Int, path: String?) {
         var params = [String:Any?]()
         params[Constants.resultFilePath] = path
         params[Constants.resultDuration] = duration
-        result(params)
+        for result in results { result(params) }
     }
     
     public func pauseRecording(_ result: @escaping FlutterResult) {

--- a/macos/Classes/AudioPlayer.swift
+++ b/macos/Classes/AudioPlayer.swift
@@ -41,20 +41,24 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
     ) {
         if !(path ?? "").isEmpty {
             self.updateFrequency = updateFrequency ?? 200
-            let audioUrl = URL.init(string: path!)
-            if audioUrl == nil {
-                result(
-                    FlutterError(
-                        code: Constants.audioWaveforms,
-                        message:
-                            "Failed to initialise Url from provided audio file",
-                        details: "If path contains `file://` try removing it"))
-                return
+            // `URL(string:)` mis-parses raw paths and truncates `file://` URLs at
+            // `#`/`?`, so strip the scheme and percent-decode for `fileURLWithPath:`.
+            let audioUrl: URL
+            if path!.hasPrefix("file://") {
+                var stripped = String(path!.dropFirst("file://".count))
+                // `file:///path` starts with `/`; `file://host/path` keeps a host
+                // segment — drop it so the host isn't folded into the file path.
+                if !stripped.hasPrefix("/"), let slash = stripped.firstIndex(of: "/") {
+                    stripped = String(stripped[slash...])
+                }
+                audioUrl = URL(fileURLWithPath: stripped.removingPercentEncoding ?? stripped)
+            } else {
+                audioUrl = URL(fileURLWithPath: path!)
             }
             do {
                 stopPlayer()
                 player = nil
-                player = try AVAudioPlayer(contentsOf: audioUrl!)
+                player = try AVAudioPlayer(contentsOf: audioUrl)
                 // macOS doesn't need AVAudioSession configuration
             } catch {
                 result(


### PR DESCRIPTION
# Description

On iOS, `stopRecording()` could return the file path **before** `AVAudioRecorder` finished writing the file to disk. `stop()` finalizes the audio container asynchronously, so reading the file or releasing the recorder immediately produced a truncated/invalid container. The recorded file then failed to load in the player with `kAudioFileInvalidFileError` ("Failed to prepare player").

This PR makes the following changes:

**1. `AudioRecorder.swift` (iOS) — defer the result until the file is finalized**
- Hold the pending `FlutterResult`(s) in a `stopResults` queue instead of returning immediately.
- Implement the `audioRecorderDidFinishRecording(_:successfully:)` delegate callback, which fires once the recorder has flushed the file to disk. The result (duration + path) is returned from there via a new `finalizeRecording(_:url:path:)` helper.
- Detach the recorder (`audioRecorder = nil`) before calling `stop()` so a subsequent `startRecording` can't redirect the URL/path that this stop is finalizing. The finishing recorder's own URL is used when finalizing.
- A 2s watchdog (guarded by a `stopGeneration` counter) force-finalizes if the delegate never fires, so Dart's `stop()` can't hang forever. A stale timer / the loser of delegate-vs-watchdog becomes a no-op.
- Re-entrant `stop()` calls now queue and all resolve with the **same** finalized result — a second `stop()` no longer returns an empty map / null path.
- Guard against an `Int(NaN)` crash when the container duration is invalid/unfinished (only convert when finite).
- If the recorder isn't actively recording when `stopRecording` is called, finalize synchronously (no callback to wait for).

**2. `AudioPlayer.swift` (iOS + macOS) — harden file URL handling**
- `URL(string:)` mis-parses raw filesystem paths that have no scheme, and truncates `file://` URLs at `#`/`?`. Now `file://` paths have the scheme stripped (and a `host` segment dropped when present), are percent-decoded, and resolved via `URL(fileURLWithPath:)`; all other paths go straight to `URL(fileURLWithPath:)`. This prevents a `nil` URL / load failure for plain file paths and for filenames containing `#`/`?`.
- The same fix is applied to the **macOS** player, which carried the identical `URL(string:)` bug introduced with macOS support.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #432

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
