### PR TITLE
fix: 🐛 Enable constant bitrate seeking for raw ADTS AAC on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed [#477](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/477) - Serialize extractor teardown with a lock and clear codec references to prevent stopping an already-released codec on Android
 - Partially fixed [#478](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/478) - Guard decode callbacks against released resources to prevent crash while extracting waveform from ID3v2.4 files on Android
 - Fixed [#488](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/488) - Auto-retry playback on transient network loss and run extraction setup off the main thread to prevent crashes and ANR on Android
+- Fixed [#429](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/429) - Enable constant bitrate seeking so raw ADTS AAC files are seekable on Android
 
 ## 2.0.2
 

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -8,6 +8,8 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.PlaybackException
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
+import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
 import io.flutter.plugin.common.MethodChannel
 
 class AudioPlayer(
@@ -54,7 +56,14 @@ class AudioPlayer(
             networkRetryCount = 0
             stop()
             player?.clearMediaItems()
-            player = ExoPlayer.Builder(appContext).build()
+            // Enable CBR seeking so headerless streams (raw ADTS .aac) are seekable (#429).
+            // Formats with their own seek info (Xing MP3, MP4/M4A, WAV) are unaffected.
+            val extractorsFactory = DefaultExtractorsFactory()
+                    .setConstantBitrateSeekingEnabled(true)
+            player = ExoPlayer.Builder(
+                    appContext,
+                    DefaultMediaSourceFactory(appContext, extractorsFactory)
+            ).build()
             player?.setMediaItem(mediaItem)
             player?.prepare()
             playerListener = object : Player.Listener {


### PR DESCRIPTION
# Description

Raw ADTS `.aac` files have no seek table inside them. On Android, ExoPlayer had no way to find a position, so seeking did nothing — playback stayed stuck at 0 and the duration came back as unknown. iOS was fine.

**What changed**

- Build the Android player so constant-bitrate seeking is turned on.
- This lets headerless constant-bitrate streams (raw ADTS AAC, and similar MP3/AMR) be seeked by estimating the byte position from the bitrate.
- Seeking and duration now work for raw `.aac` on Android, matching iOS.

Files that already carry their own seek info (MP3 with a Xing header, MP4/M4A, WAV) are untouched and keep using it.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #429

<!-- Links -->

[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
