### PR TITLE
feat: ✨ Add WaveStyle.maxDuration for proportional recording width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
+- Feature [#91](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/91) - Add `WaveStyle.maxDuration` to bound recording waveform width proportionally
 
 ## 2.0.2
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -847,6 +847,34 @@ AudioWaveforms(
 )
 ```
 
+## Bounded Recording Width
+
+By default the recording waveform scrolls once it reaches the middle of the
+available width. Set `WaveStyle.maxDuration` to instead bound the waveform to a
+fixed maximum duration: the waveform fills only
+`elapsedRecordingDuration / maxDuration` of the width and never scrolls. For
+example, with a `maxDuration` of 10 seconds, stopping the recording at 5 seconds
+draws the waveform across half of the width; reaching 10 seconds fills the full
+width (recording past it stays clamped to the full width).
+
+This is useful when you want the final waveform length to reflect how long the
+recording is, relative to a cap.
+
+```dart
+AudioWaveforms(
+  controller: recorderController,
+  size: Size(MediaQuery.of(context).size.width, 100),
+  waveStyle: const WaveStyle(
+    maxDuration: Duration(seconds: 10),
+  ),
+)
+```
+
+> Note: `maxDuration` only applies to `WaveformRenderMode.ltr` (ignored for
+> `rtl`, like `extendWaveform`) and takes precedence over `extendWaveform` when
+> both are set. A non-positive value (`Duration.zero` or less) is ignored and
+> falls back to the default scrolling behavior.
+
 ## Waveform Gradients
 
 Apply gradients to waveforms:
@@ -1708,6 +1736,7 @@ This section provides a quick reference for the main classes and their propertie
 | `durationLinesHeight` | `double`    | -                  | Duration line height  |
 | `gradient`            | `Shader?`   | `null`             | Wave gradient         |
 | `scaleFactor`         | `double`    | `20.0`             | Wave scaling factor   |
+| `maxDuration`         | `Duration?` | `null`             | Bound recording width |
 
 ## PlayerWaveStyle (for Player)
 

--- a/lib/src/audio_waveforms.dart
+++ b/lib/src/audio_waveforms.dart
@@ -157,6 +157,7 @@ class _AudioWaveformsState extends State<AudioWaveforms> {
                 scaleFactor: _waveStyle.scaleFactor,
                 currentlyRecordedDuration: currentlyRecordedDuration,
                 isRtl: _isRtl,
+                maxDuration: _waveStyle.maxDuration,
               ),
             ),
           ),

--- a/lib/src/base/wave_style.dart
+++ b/lib/src/base/wave_style.dart
@@ -31,6 +31,7 @@ class WaveStyle {
     this.gradient,
     this.scaleFactor = 20.0,
     this.waveformRenderMode = WaveformRenderMode.ltr,
+    this.maxDuration,
   }) : assert(
           waveThickness < spacing,
           "waveThickness can't be greater than spacing",
@@ -133,4 +134,23 @@ class WaveStyle {
   /// to left. Older waves will be pushed to the left to make space for new
   /// waves.
   final WaveformRenderMode waveformRenderMode;
+
+  /// Bounds the recording waveform to a fixed maximum duration.
+  ///
+  /// When provided, the waveform is no longer scrolled. Instead it fills only
+  /// the fraction of the available width equal to
+  /// `elapsedRecordingDuration / maxDuration`. e.g. with `maxDuration` of 10s,
+  /// stopping the recording at 5s draws the waveform across half of the width;
+  /// reaching `maxDuration` fills the full width. Recording past `maxDuration`
+  /// is clamped to the full width.
+  ///
+  /// Can only be used with [WaveformRenderMode.ltr] (ignored for
+  /// [WaveformRenderMode.rtl], like [extendWaveform]). When set, it takes
+  /// precedence over [extendWaveform].
+  ///
+  /// A non-positive value (less than or equal to [Duration.zero]) is ignored
+  /// and falls back to the default scrolling behavior.
+  ///
+  /// Defaults to `null`, which keeps the default scrolling behavior.
+  final Duration? maxDuration;
 }

--- a/lib/src/painters/recorder_wave_painter.dart
+++ b/lib/src/painters/recorder_wave_painter.dart
@@ -48,6 +48,7 @@ class RecorderWavePainter extends CustomPainter {
     required this.currentlyRecordedDuration,
     required this.labels,
     required this.isRtl,
+    required this.maxDuration,
   })  : _wavePaint = Paint()
           ..color = waveColor
           ..strokeWidth = waveThickness
@@ -98,6 +99,15 @@ class RecorderWavePainter extends CustomPainter {
   final List<Label> labels;
   final bool isRtl;
 
+  /// When non-null (LTR only), the waveform is bounded to this duration and
+  /// fills `currentlyRecordedDuration / maxDuration` of the width instead of
+  /// scrolling. See [WaveStyle.maxDuration].
+  final Duration? maxDuration;
+
+  /// Whether bounded (max-duration) mode is active. A non-positive
+  /// [maxDuration] is ignored and falls back to the default scrolling behavior.
+  bool get _isBounded => maxDuration != null && maxDuration!.inMicroseconds > 0;
+
   static const int durationBuffer = 5;
 
   @override
@@ -121,9 +131,12 @@ class RecorderWavePainter extends CustomPainter {
       }
     } else {
       for (var i = 0; i < waveData.length; i++) {
-        if (((spacing * i) + dragOffset.dx + spacing >
-                size.width / (extendWaveform ? 1 : 2) +
-                    totalCurrentBackDistance.dx) &&
+        // When [maxDuration] is set the waveform is bounded to the width and
+        // never scrolls, so pushBack is skipped.
+        if (!_isBounded &&
+            ((spacing * i) + dragOffset.dx + spacing >
+                    size.width / (extendWaveform ? 1 : 2) +
+                        totalCurrentBackDistance.dx) &&
             callPushback) {
           pushBack();
         }
@@ -207,10 +220,17 @@ class RecorderWavePainter extends CustomPainter {
   /// Draw wave for LTR direction
   void _drawLtrWave(Canvas canvas, Size size, int i) {
     final height = size.height;
-    final dx = -totalCurrentBackDistance.dx +
-        dragOffset.dx +
-        (spacing * i) -
-        initialPosition;
+    final double dx;
+    if (_isBounded) {
+      // Bounded mode: distribute the current samples across the fraction of
+      // the width equal to currentlyRecordedDuration / maxDuration. No scroll.
+      dx = _boundedDx(size, i);
+    } else {
+      dx = -totalCurrentBackDistance.dx +
+          dragOffset.dx +
+          (spacing * i) -
+          initialPosition;
+    }
     final scaledWaveHeight = waveData[i] * scaleFactor;
     final upperDy = height - (showTop ? scaledWaveHeight : 0) - bottomPadding;
     final lowerDy =
@@ -223,13 +243,34 @@ class RecorderWavePainter extends CustomPainter {
     // portions of waves are being drawn to user
     // and [dx > 0] will ensure only fully visible waves are drawn,
     // if any wave is half visible this will cut out that wave too.
-    if (dx > 0 && dx < size.width) {
+    //
+    // In bounded ([maxDuration]) mode the waves are clamped within the width,
+    // so the first wave at dx == 0 and the last at dx == size.width are kept.
+    final isVisible = _isBounded
+        ? (dx >= 0 && dx <= size.width)
+        : (dx > 0 && dx < size.width);
+    if (isVisible) {
       canvas.drawLine(
         Offset(dx, upperDy),
         Offset(dx, lowerDy),
         _wavePaint,
       );
     }
+  }
+
+  /// Horizontal position of wave [i] when [maxDuration] is set.
+  ///
+  /// The current samples are spread across `fraction * size.width`, where
+  /// `fraction = currentlyRecordedDuration / maxDuration` (clamped to 1). So
+  /// the waveform grows left-to-right and reaches the full width exactly at
+  /// [maxDuration].
+  double _boundedDx(Size size, int i) {
+    final maxMicros = maxDuration!.inMicroseconds;
+    if (maxMicros <= 0 || waveData.length <= 1) return 0;
+    final fraction =
+        (currentlyRecordedDuration.inMicroseconds / maxMicros).clamp(0.0, 1.0);
+    final effectiveSpacing = (fraction * size.width) / (waveData.length - 1);
+    return effectiveSpacing * i;
   }
 
   /// Draw wave for RTL direction


### PR DESCRIPTION
# Description

Adds `WaveStyle.maxDuration` so the recording waveform can be bound to a fixed maximum duration instead of scrolling.

Today the recording waveform grows until it hits the middle of the width and then scrolls left, so every recording ends up looking the same length no matter how long it actually was. There was no way to make the drawn length reflect the recording length.

**What changed**

- New optional `WaveStyle.maxDuration`.
- When set, the waveform no longer scrolls. It fills only `elapsedRecordingDuration / maxDuration` of the available width.
- Example: with `maxDuration` of 10s, stopping at 5s draws across half the width; reaching 10s fills the full width; recording past 10s stays clamped to the full width.
- LTR only (ignored for RTL, like `extendWaveform`) and takes precedence over `extendWaveform` when both are set.
- Fully backward compatible: default is `null`, which keeps the existing scrolling behavior unchanged.

## UI Changes

When `maxDuration` is set, the recording waveform stays inside the box and its length now reflects how far the recording is toward the cap, instead of growing and scrolling. No change when `maxDuration` is unset.

### Before (without `maxDuration`)

https://github.com/user-attachments/assets/e4739222-58bb-41c6-8089-d8ed21f70ec2

### After (optional `maxDuration` set to 10s)

https://github.com/user-attachments/assets/7bcff8a3-b039-490f-b187-1210afc6d1df

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #91
