### PR TITLE
build: ⬆️ Migrate Android playback from ExoPlayer 2 to Media3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
+- Chore [#509](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/509) - Migrate Android playback from ExoPlayer 2.17.1 to Media3 1.11.0
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.3
+## 2.1.0 (#unreleased)
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
 - Chore [#509](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/509) - Migrate Android playback from ExoPlayer 2.17.1 to Media3 1.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 2.1.0 (#unreleased)
+## 2.0.3
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
 - Chore [#509](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/509) - Migrate Android playback from ExoPlayer 2.17.1 to Media3 1.11.0
-- Docs [#509](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/509) - Document Android compileSdk 36 requirement for Media3
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Feature [#468](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/pull/468) - Add macOS support
 - Chore [#509](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/509) - Migrate Android playback from ExoPlayer 2.17.1 to Media3 1.11.0
+- Docs [#509](https://github.com/SimformSolutionsPvtLtd/audio_waveforms/issues/509) - Document Android compileSdk 36 requirement for Media3
 
 ## 2.0.2
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
         namespace "com.simform.audio_waveforms"
     }
 
-    compileSdk 34
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -45,11 +45,11 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
     }
 }
 
 dependencies {
     implementation("androidx.multidex:multidex:2.0.1")
-    implementation "com.google.android.exoplayer:exoplayer:2.17.1"
+    implementation "androidx.media3:media3-exoplayer:1.11.0"
 }

--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.PlaybackException
-import com.google.android.exoplayer2.Player
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import io.flutter.plugin.common.MethodChannel
 
+@OptIn(UnstableApi::class)
 class AudioPlayer(
         context: Context,
         channel: MethodChannel,
@@ -50,15 +52,15 @@ class AudioPlayer(
                     result.error(Constants.LOG_TAG, error.message, "Unable to load media source.")
                 }
 
-                override fun onPlayerStateChanged(isReady: Boolean, state: Int) {
+                override fun onPlaybackStateChanged(playbackState: Int) {
                     if (!isPlayerPrepared) {
-                        if (state == Player.STATE_READY) {
+                        if (playbackState == Player.STATE_READY) {
                             player?.volume = volume ?: 1F
                             isPlayerPrepared = true
                             result.success(true)
                         }
                     }
-                    if (state == Player.STATE_ENDED) {
+                    if (playbackState == Player.STATE_ENDED) {
                         val args: MutableMap<String, Any?> = HashMap()
                         when (finishMode) {
                             FinishMode.Stop -> {

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -144,6 +144,14 @@ Change the minimum Android SDK version to 23 (or higher) in your `android/app/bu
 minSdkVersion 23
 ```
 
+#### Update compile SDK version
+
+Android playback uses Media3, which requires compile SDK 36 (or higher):
+
+```gradle
+compileSdk 36
+```
+
 #### Add permissions
 
 Add RECORD_AUDIO permission in `AndroidManifest.xml`:

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace "com.simform.audio_waveforms_example"
     }
-    compileSdk 35
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
# Description

Standalone ExoPlayer 2 is discontinued. Android playback now uses Media3 ExoPlayer 1.11.0. The Dart `PlayerController` API is unchanged. Plugin `minSdk` is aligned to 23 (already documented) and `compileSdk` is 36 (required by Media3 1.11.0).

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

There are no Android instrumented tests in this repo. Verified with `flutter build apk --debug` and by running the example app on an Android emulator (local MP3 prepare/play/pause). Gradle no longer resolves `com.google.android.exoplayer2`.

Android setup docs now require `compileSdk 36`. The example app `compileSdk` is updated to match. No Dart API or dartdoc changes.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #509

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org