### PR TITLE
fix: 🐛 Decode 8-bit, 16-bit and float PCM samples correctly on Android

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.util.Log
 import io.flutter.plugin.common.MethodChannel
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.util.concurrent.CountDownLatch
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -299,7 +300,10 @@ class WaveformExtractor(
      */
     private fun handle8bit(size: Int, buf: ByteBuffer) {
         repeat(size / if (channels == 2) 2 else 1) {
-            val result = buf.get().toInt() / Constants.EIGHT_BITS
+            // ENCODING_PCM_8BIT is unsigned, with 128 as silence, while a Kotlin
+            // Byte is signed: it has to be widened and then centered on zero.
+            val sample = (buf.get().toInt() and 0xFF) - 128
+            val result = sample / Constants.EIGHT_BITS
             if (channels == 2) {
                 buf.get()
             }
@@ -318,9 +322,13 @@ class WaveformExtractor(
      */
     private fun handle16bit(size: Int, buf: ByteBuffer) {
         repeat(size / if (channels == 2) 4 else 2) {
-            val first = buf.get().toInt()
-            val second = buf.get().toInt() shl 8
-            val value = (first or second) / Constants.SIXTEEN_BITS
+            // Little endian, low byte first. The low byte has to be masked: a
+            // Kotlin Byte above 0x7F widens to a negative Int, and its sign bits
+            // then swallow the high byte through the `or`. The high byte is left
+            // signed on purpose — that is the sample's own sign.
+            val low = buf.get().toInt() and 0xFF
+            val high = buf.get().toInt() shl 8
+            val value = (low or high) / Constants.SIXTEEN_BITS
             if (channels == 2) {
                 buf.get()
                 buf.get()
@@ -330,26 +338,21 @@ class WaveformExtractor(
     }
 
     /**
-     * Processes 32-bit PCM audio data
+     * Processes 32-bit float PCM audio data
      *
-     * Reads 32-bit samples from the buffer, normalizes them to the range [-1.0, 1.0],
-     * and passes them to handleBufferDivision for RMS calculation.
-     * 
+     * A pcmEncodingBit of 32 is only ever set for AudioFormat.ENCODING_PCM_FLOAT,
+     * so the samples are IEEE-754 floats already in the range [-1.0, 1.0] and are
+     * read as such, then passed to handleBufferDivision for RMS calculation.
+     *
      * @param size Size of the buffer in bytes
      * @param buf ByteBuffer containing the audio data
      */
     private fun handle32bit(size: Int, buf: ByteBuffer) {
+        val floats = buf.order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
         repeat(size / if (channels == 2) 8 else 4) {
-            val first = buf.get().toLong()
-            val second = buf.get().toLong() shl 8
-            val third = buf.get().toLong() shl 16
-            val forth = buf.get().toLong() shl 24
-            val value = (first or second or third or forth) / Constants.THIRTY_TWO_BITS
+            val value = floats.get()
             if (channels == 2) {
-                buf.get()
-                buf.get()
-                buf.get()
-                buf.get()
+                floats.get()
             }
             handleBufferDivision(value)
         }


### PR DESCRIPTION
# Description

`WaveformExtractor` mis-reads the decoder's PCM output in all three of its bit-depth paths, so the extracted waveform does not match the audio. Nothing crashes — the waveform simply has the wrong shape — which is why this has been easy to miss. Full analysis and a value-by-value comparison are in #512.

**16-bit** (`handle16bit`), the default and most common path:

```kotlin
val first = buf.get().toInt()          // signed: 0x80..0xFF widen to negative
val second = buf.get().toInt() shl 8
val value = (first or second) / Constants.SIXTEEN_BITS
```

`buf.get()` returns a signed `Byte`, so a low byte above `0x7F` widens to a negative `Int` whose sign bits then swallow the high byte through the `or`. Full-scale `+32767` decodes as `-0.00003`. Since about half of all samples have a low byte ≥ `0x80`, roughly half collapse toward zero, making the waveform attenuated and noisy rather than visibly broken. Fixed by masking the low byte with `and 0xFF`; the high byte stays signed, because that is the sample's own sign.

**8-bit** (`handle8bit`): `AudioFormat.ENCODING_PCM_8BIT` is unsigned with 128 as silence, but the byte was read as a signed `Byte` and never centered, so silence decoded as full-scale negative. Fixed by widening with `and 0xFF` and subtracting 128.

**32-bit** (`handle32bit`): `pcmEncodingBit` is only ever set to 32 for `AudioFormat.ENCODING_PCM_FLOAT` (in `onOutputFormatChanged`), so these samples are IEEE-754 floats already in `[-1.0, 1.0]`. They were assembled byte-by-byte as an integer and divided by `2^31`, which made `+1.0` and `-1.0` both decode as `-0.0039`. Fixed by reading them as floats via `asFloatBuffer()`, which also simplifies the stereo channel skip.

No public API changes, and no behavioral change beyond the decoded values being correct.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

On tests: the Android source set has no test harness today (`android/src/` contains only `main`, and there are no JUnit dependencies or `testOptions` in `android/build.gradle`), and these three functions are private and read instance state, so there is nowhere to hang a unit test without first introducing the JVM test setup. I did not want to bundle that decision into a bug fix. The issue instead documents the exact input/output pairs for each path, and I am happy to add a proper test — extracting the arithmetic into testable helpers, plus the JUnit wiring — if you would like it in this PR or a follow-up.

Docs and examples are not applicable: this is an internal native decoding change with no surface in the Dart API.

Verified with `./gradlew :audio_waveforms:compileDebugKotlin` (clean; the two remaining warnings are pre-existing, in `AudioPlayer.kt`) and by decoding known sample values through both the old and the new arithmetic.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

Waveforms extracted on Android will change shape, but only to become correct — they will now match what iOS produces for the same file.

## Related Issues

Fixes #512

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org

Made with [Cursor](https://cursor.com)