### PR TITLE
fix: make WaveformExtractor.stop() idempotent

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/WaveformExtractor.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import io.flutter.plugin.common.MethodChannel
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.pow
 import kotlin.math.sqrt
 import androidx.core.net.toUri
@@ -68,6 +69,8 @@ class WaveformExtractor(
     private var perSamplePoints = 0L
     /** Flag to prevent submitting multiple results */
     private var isReplySubmitted = false
+    /** Guards [stop] so the codec is only stopped and released once */
+    private val isStopped = AtomicBoolean(false)
 
     /**
      * Retrieves the audio format from the given media file
@@ -402,9 +405,32 @@ class WaveformExtractor(
      * 3. Signals completion via the countdown latch
      */
     fun stop() {
-        decoder?.stop()
-        decoder?.release()
-        extractor?.release()
+        // stop() reaches us from two threads: the MediaCodec callback thread
+        // when decoding finishes on its own, and the platform thread when
+        // Flutter calls stopExtraction (PlayerController.dispose does this).
+        // Whichever loses the race would otherwise call stop() on a codec that
+        // is already released, which throws IllegalStateException.
+        if (!isStopped.compareAndSet(false, true)) return
+
+        try {
+            decoder?.stop()
+        } catch (e: IllegalStateException) {
+            Log.w(Constants.LOG_TAG, "Decoder already stopped: ${e.message}")
+        }
+        try {
+            decoder?.release()
+        } catch (e: IllegalStateException) {
+            Log.w(Constants.LOG_TAG, "Decoder already released: ${e.message}")
+        }
+        decoder = null
+
+        try {
+            extractor?.release()
+        } catch (e: IllegalStateException) {
+            Log.w(Constants.LOG_TAG, "Extractor already released: ${e.message}")
+        }
+        extractor = null
+
         finishCount.countDown()
     }
 }


### PR DESCRIPTION
stop() is reachable from two threads: the MediaCodec callback thread, when decoding completes on its own (handleBufferDivision once progress exceeds 1.0, and onOutputBufferAvailable at EOF), and the platform thread, when Flutter calls stopExtraction — which PlayerController.dispose does unconditionally, and which createOrUpdateExtractor does before starting a new extraction on the same key.

Because the decoder reference was never cleared and stop() had no guard, the later caller invoked MediaCodec.stop() on an already-released codec:

  java.lang.IllegalStateException: codec is released already
    at android.media.MediaCodec.native_stop(Native Method)
    at android.media.MediaCodec.stop(MediaCodec.java:2579)

On the Flutter side this surfaces as a PlatformException thrown out of PlayerController.dispose(), which is `void ... async`, so it escapes as an unhandled async error rather than something callers can catch.

Guard stop() with an AtomicBoolean compare-and-set, tolerate IllegalStateException on each release, and null out decoder/extractor afterwards — which also makes the existing null checks in onInputBufferAvailable and onOutputBufferAvailable effective, where previously they could never fire.

iOS is unaffected: WaveformExtractor.cancel() is already flag-guarded.

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require audio_waveforms users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/audio_waveforms/blob/master/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
